### PR TITLE
Add 'name' attribute to the cookbook metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "ohai-private-ipaddress"
 maintainer       "Wanelo.com"
 maintainer_email "ops@wanelo.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Add the `name` attribute to the metadata file. I was encountering the following error in chef-client without it.

`2015-07-15_15:06:12.26836 FATAL: Chef::Exceptions::MetadataNotValid: Cookbook loaded at path(s) [/var/chef/git/tmp/librarian/cookbooks/ohai-private-ipaddress] has invalid metadata: The `name' attribute is required in cookbook metadata`